### PR TITLE
Removed the indent guide on the first column

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,4 +1,4 @@
-.cm-lkcampbell-indent-guides {
+.cm-lkcampbell-indent-guides:not(:first-child) {
     position: relative;
     background-image: url(indent-guide.svg);
     background-repeat: repeat-y;


### PR DESCRIPTION
Since the gutter effectively acts as the first indentation guide at position zero I made the extension starts drawing the guides after the first indentation. Makes it look a bit cleaner without losing clarity.
