### PR TITLE
german translation

### DIFF
--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -27,7 +27,6 @@
 
 define({
 	COMMAND_NAME: "Einzugshilfslinien",
-
 	DESCRIPTION_ENABLED: "Entscheidet, ob die Einzugshilfslinien angezeigt werden.",
 	DESCRIPTION_HIDE_FIRST: "Entscheidet, ob die erste Einzugshilfslinien angezeigt wird.",
 	DESCRIPTION_GUIDE_COLOR: "Die Farbe der Hilfslinien. Jeder valide CSS Farbwert ist möglich.",

--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Lance Campbell. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
+
+define({
+	COMMAND_NAME: "Einzugshilfslinien",
+
+	DESCRIPTION_ENABLED: "Entscheidet, ob die Einzugshilfslinien angezeigt werden.",
+	DESCRIPTION_HIDE_FIRST: "Entscheidet, ob die erste Einzugshilfslinien angezeigt wird.",
+	DESCRIPTION_GUIDE_COLOR: "Die Farbe der Hilfslinien. Jeder valide CSS Farbwert ist möglich.",
+	DESCRIPTION_GUIDE_STYLE: "Wählt den Stil der Hilfslinie: 'solid'(durchgezogen) oder 'dotted'(gepunktet)."
+});

--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -28,7 +28,7 @@
 define({
 	COMMAND_NAME: "Einzugshilfslinien",
 	DESCRIPTION_ENABLED: "Entscheidet, ob die Einzugshilfslinien angezeigt werden.",
-	DESCRIPTION_HIDE_FIRST: "Entscheidet, ob die erste Einzugshilfslinien angezeigt wird.",
+	DESCRIPTION_HIDE_FIRST: "Entscheidet, ob die erste Einzugshilfslinie angezeigt wird.",
 	DESCRIPTION_GUIDE_COLOR: "Die Farbe der Hilfslinien. Jeder valide CSS Farbwert ist möglich.",
 	DESCRIPTION_GUIDE_STYLE: "Wählt den Stil der Hilfslinie: 'solid'(durchgezogen) oder 'dotted'(gepunktet)."
 });

--- a/nls/strings.js
+++ b/nls/strings.js
@@ -27,16 +27,17 @@
 
 define(function (require, exports, module) {
 
-    'use strict';
+	'use strict';
 
-    // Code that needs to display user strings should call require("strings") to load
-    // strings.js. This file will dynamically load strings.js for the specified by bracketes.locale.
-    // 
-    // Translations for other locales should be placed in nls/<locale<optional country code>>/strings.js
-    // Localization is provided via the i18n plugin.
-    // All other bundles for languages need to add a prefix to the exports below so i18n can find them.
-    // TODO: dynamically populate the local prefix list below?
-    module.exports = {
-        root: true
-    };
+	// Code that needs to display user strings should call require("strings") to load
+	// strings.js. This file will dynamically load strings.js for the specified by bracketes.locale.
+	// 
+	// Translations for other locales should be placed in nls/<locale<optional country code>>/strings.js
+	// Localization is provided via the i18n plugin.
+	// All other bundles for languages need to add a prefix to the exports below so i18n can find them.
+	// TODO: dynamically populate the local prefix list below?
+	module.exports = {
+		root: true,
+		de: true
+	};
 });


### PR DESCRIPTION
I just translated the string.js to german.
The last line is now
> DESCRIPTION_GUIDE_STYLE: "Wählt den Stil der Hilfslinie: **'solid'(durchgezogen)** oder **'dotted'(gepunktet)**."

because I wanted to add a german translation but keep the actual value for the style.

this is my first pull request, i hope everything is ok ;)